### PR TITLE
contentBase was renamed to static

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ const config = {
   devtool: "eval-cheap-source-map",
   devServer: {
     port: 8080,
-    contentBase: path.resolve(__dirname, "dist"),
+    static: path.resolve(__dirname, "dist"),
     hot: true
   },
   module: {


### PR DESCRIPTION
contentBase was throwing me an "...options has an unknown property 'contentBase'. " error and apparently it was renamed to static.